### PR TITLE
Make `webcompat-bug-report` semantic.

### DIFF
--- a/.github/ISSUE_TEMPLATE/webcompat-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/webcompat-bug-report.md
@@ -1,37 +1,45 @@
 ---
-name: Webcompat Bug report
+name: Webcompat Bug Report
 about: Create a report to help us improve
-title: domain name - very short summary
+title: domain name – a very short summary
 labels: status-needsinfo-oana, status-needsinfo-sergiu, status-needsinfo-cipriansv
 assignees: ''
-
 ---
 
-**URL**:
+#### URL
 
-**Browser/Version**:
 
-**Operating System**:
 
-**What seems to be the trouble?(Required)**
-- [ ] Desktop site instead of mobile site
+#### Browser/Version
+
+
+
+#### Operating System
+
+
+
+#### What The Problem Is <!-- (Required) -->
+
+- [ ] Desktop site, instead of mobile site
 - [ ] Mobile site is not usable
 - [ ] Video doesn't play
 - [ ] Layout is messed up
 - [ ] Text is not visible
-- [ ] Something else (Add details below)
+- [ ] Something else <!-- (Add details below) -->
 
-**Steps to Reproduce**
+#### Steps To Reproduce
 
-1. Navigate to: (*site url*)
-2. *Any additional steps to be taken*
+1. <!-- Navigate to: (*site url*) -->
+  
+2. <!-- Any additional steps to be taken -->
 
-*__Expected Behavior:__*
-
-
-*__Actual Behavior:__*
+#### Expected Behavior
 
 
-**Screenshot**
+#### Actual Behavior
 
-![Add Screenshot](https://your/screenshot/url/here.png "Screenshot Descriptions")
+
+#### Screenshot
+
+<!-- ![Add Screenshot](https://your/screenshot/url/here.png "Screenshot Descriptions") -->
+


### PR DESCRIPTION
#### Improvements

1. The headings are, now, semantically so (for the sake of screen readers), rather than being poor CSS3 imitations (despite being colon-delimited, which is redundant).

1. Minor punctuation that was previously erroneously absent has been added, like a comma after “Desktop site”.

1. The `name` key of the YAML preamble is consistently title case.

1. The hyphen-minus after “domain name” is, now, an en dash, which is grammatically correct.

1. Placeholders are commented, so that naïve issue authors do not need to worry about whether they need to retain them, because they can't render regardless.

1. The headings are consistently titles, and therefore title case.

1. Removing the `/n` at the bottom of the YAML preamble enables syntax highlighting in GH's UI.

With this, it should pass WCAG.

#### Unmodified

I've left no `/n`s between each `li`, due to [`github/markup/issues/1857`](https://github.com/github/markup/issues/1857#issuecomment-2976452922).

#### Context

Resolves [`issues/208984#issuecomment-4054625307`](https://github.com/webcompat/web-bugs/issues/208984#issuecomment-4054625307).